### PR TITLE
MM-98: follow testthat issue fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mvMAPIT
 Title: Multivariate Genome Wide Marginal Epistasis Test
-Version: 2.0.0.1
+Version: 2.0.1
 URL: https://github.com/lcrawlab/mvMAPIT, https://lcrawlab.github.io/mvMAPIT/
 Authors@R: c(
     person("Julian", "Stamp", email = "julian_stamp@brown.edu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,4 +68,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 LazyDataCompression: xz
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
 # mvMAPIT (development version)
 
+# mvMAPIT 2.0.1 release
 
-# mvMAPIT 2.0.0.1 release
+* Fix LTO issues when submitting to CRAN. The testthat issue https://github.com/r-lib/testthat/issues/1230
+describes the solution chosen. Created this github gist to reproduce LTO errors: https://gist.github.com/jdstamp/056475683110aacdb1e6761872ab1e05.
+
+# mvMAPIT 2.0.0.1 pre-release
 
 * CRAN issue does not show up in `R CMD check`. Version upgrade for resubmission.
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -30,11 +30,11 @@ BEGIN_RCPP
 END_RCPP
 }
 
-RcppExport SEXP run_testthat_tests();
+RcppExport SEXP run_testthat_tests(SEXP use_xml_sxp);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_mvMAPIT_MAPITCpp", (DL_FUNC) &_mvMAPIT_MAPITCpp, 8},
-    {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 0},
+    {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 1},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
https://github.com/r-lib/testthat/issues/1230

Gist to reproduce error: https://gist.github.com/jdstamp/056475683110aacdb1e6761872ab1e05